### PR TITLE
Use SHA1 commit number to clone Odoo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,9 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 # SM: Add Odoo sources (remove .git folder to reduce image size)
 WORKDIR /opt/odoo/sources
 RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
-      cd odoo && \
-      git reset --hard c0a2bc8e547d7aca64a3a99cea65a939b4ebff98 && \
-      rm -rf .git
+  cd odoo && \
+  git reset --hard c0a2bc8e547d7aca64a3a99cea65a939b4ebff98 && \
+  rm -rf .git
 
 # Execution environment
 USER 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 WORKDIR /opt/odoo/sources
 RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
       cd odoo && \
-      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406
+      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406 \
       rm -rf .git
 
 # Execution environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 WORKDIR /opt/odoo/sources
 RUN git clone https://github.com/odoo/odoo.git -b 9.0 --depth 1 odoo && \
       cd odoo && \
-      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406 && \
+      git reset --hard be5fc7b1a4fe91272bc48d16068ad299aa6585ba && \
       rm -rf .git
 
 # Execution environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 
 # SM: Add Odoo sources (remove .git folder to reduce image size)
 WORKDIR /opt/odoo/sources
-RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
+RUN git clone https://github.com/odoo/odoo.git -b 9.0 --depth 1 odoo && \
       cd odoo && \
       git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406 && \
       rm -rf .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 WORKDIR /opt/odoo/sources
 RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
       cd odoo && \
-      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406 \
+      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406 && \
       rm -rf .git
 
 # Execution environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,9 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 
 # SM: Add Odoo sources (remove .git folder to reduce image size)
 WORKDIR /opt/odoo/sources
-RUN git clone https://github.com/odoo/odoo.git -b 9.0 --depth 1 odoo && \
+RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
       cd odoo && \
-      git reset --hard be5fc7b1a4fe91272bc48d16068ad299aa6585ba && \
+      git reset --hard c0a2bc8e547d7aca64a3a99cea65a939b4ebff98 && \
       rm -rf .git
 
 # Execution environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,9 @@ RUN /bin/bash -c "mkdir -p /opt/odoo/var/{run,log,egg-cache}"
 # SM: Add Odoo sources (remove .git folder to reduce image size)
 WORKDIR /opt/odoo/sources
 RUN git clone https://github.com/odoo/odoo.git -b 9.0 odoo && \
-       rm -rf odoo/.git
+      cd odoo && \
+      git reset --hard 7592d85b1fe7e4e7cd4473d263d145380b8ed406
+      rm -rf .git
 
 # Execution environment
 USER 0


### PR DESCRIPTION
Changing the SHA1 will force to rebuild the Docker image. Also it allows to ensure which version has been built exactly.