### PR TITLE
There are no ajax.googleapis.com links anymore in v9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,4 @@ RUN apt-get update && \
   apt-get -y install ttf-wqy-zenhei
 
 # Google links CN mirror
-# Also replace "http://" with "//" to fix mixed-content issue on HTTPS pages
-RUN sed -i "s/http:\/\/fonts.googleapis.com/\/\/fonts.lug.ustc.edu.cn/g" `grep 'fonts.googleapis.com' -rl /opt/odoo/sources/odoo/addons`
-RUN sed -i "s/http:\/\/ajax.googleapis.com/\/\/ajax.lug.ustc.edu.cn/g" `grep 'ajax.googleapis.com' -rl /opt/odoo/sources/odoo/addons`
+RUN sed -i "s/fonts.googleapis.com/fonts.lug.ustc.edu.cn/g" `grep 'fonts.googleapis.com' -rl /opt/odoo/sources/odoo/addons`


### PR DESCRIPTION
Also the fonts.googleapis.com are now prefixed by "//", not "http://" anymore.