### PR TITLE
missing 'POSTGRES_DB=postgres' to docker-compose.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ more information about Compose, see the [official documentation][dc-doc].
         image: postgres:9.5
         environment:
           - POSTGRES_USER=odoo
+          - POSTGRES_DB=postgres
 
       odoo:
         image: elicocorp/odoo:10.0


### PR DESCRIPTION
It might be needed for other examples, but I didn't test other scenarios yet.